### PR TITLE
fix: restore runner dependencies and parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 *.db
 *.sqlite
 *.sqlite3
+project_st_v6/parsed/
+project_st_v6/reports/
+project_st_v6/__pycache__/
+project_st_v6/parsed_all.json
 
 # Application data directories
 gemeni_csv/data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# csv_data-
+# csv_data
+
+## 실행 전 준비
+- Python 3.10 이상이 설치되어 있어야 합니다.
+- (선택) 가상환경을 사용하는 것을 권장합니다.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+```
+
+필수 패키지는 프로젝트 루트의 `project_st_v6/requirements.txt` 에 정의되어 있습니다.
+
+```bash
+pip install -r project_st_v6/requirements.txt
+```
+
+## 실행 방법
+
+### 1. Streamlit 웹 앱 실행
+문서를 업로드하고 분석 리포트를 생성하는 웹 UI를 사용하려면 다음 명령을 실행합니다.
+
+```bash
+cd project_st_v6
+streamlit run app.py
+```
+
+브라우저에서 표시되는 주소(기본값: http://localhost:8501)를 열어 인터페이스에 접근할 수 있습니다.
+
+### 2. 커맨드라인 리포트 생성기 실행
+로컬에 저장된 문서를 기반으로 리포트를 생성하려면 아래 명령을 실행합니다.
+
+```bash
+cd project_st_v6
+python runner.py
+```
+
+`docs/` 폴더의 문서를 파싱한 뒤, 결과 리포트를 `reports/analysis.md` 로 저장합니다.
+
+## 추가 참고
+- `parsed_all.json` 파일이 존재하면 Streamlit 애플리케이션의 분석에 사용됩니다.
+- `runner.py` 는 `docs/` 폴더 내 파일을 기반으로 자동으로 리포트를 생성합니다.

--- a/project_st_v6/parser.py
+++ b/project_st_v6/parser.py
@@ -1,23 +1,143 @@
-# parser.py
-import re
+"""Utilities for parsing domain documents into structured data."""
+
+from __future__ import annotations
+
 import json
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List, Union
 
-def parse_content(content: str):
-    """문서 내용에서 규칙/사례/용어 등 단순 패턴 기반 추출"""
-    rules = []
 
-    # 예시 패턴: "…의 상", "…법", "…원리", "…의미"
-    for match in re.finditer(r"([^\s]+의\s?(상|법|원리|의미))", content):
+TEXT_EXTENSIONS = {".txt", ".md", ".csv"}
+
+
+def parse_content(content: str) -> Dict[str, List[Dict[str, str]]]:
+    """간단한 패턴 매칭을 사용해 문서 내용에서 규칙 후보를 추출합니다."""
+
+    rules: List[Dict[str, str]] = []
+
+    pattern = re.compile(r"([^\s]+의\s?(상|법|원리|의미))")
+    for match in pattern.finditer(content):
         title = match.group(1)
-        rules.append({
-            "category": "rule",
-            "title": title,
-            "content": content[max(0, match.start()-50):match.end()+100]  # 앞뒤 문맥 포함
-        })
+        snippet = content[max(0, match.start() - 50): match.end() + 100]
+        rules.append(
+            {
+                "category": "rule",
+                "title": title,
+                "content": snippet.strip(),
+            }
+        )
 
     return {"rules": rules}
 
-def save_parsed(data, filename="parsed_all.json"):
-    """저장 버튼 눌렀을 때만 실행"""
-    with open(filename, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
+
+def _normalize_json_rules(data: Union[Dict, List], source: str) -> Dict[str, List[Dict[str, str]]]:
+    """사전에 작성된 JSON 문서를 규칙 리스트로 맞춰줍니다."""
+
+    rules: List[Dict[str, str]] = []
+
+    if isinstance(data, dict):
+        candidates: Iterable = ()
+        if isinstance(data.get("rules"), dict):
+            candidates = data["rules"].items()
+        elif isinstance(data.get("rules"), list):
+            # 이미 표준 구조
+            for entry in data["rules"]:
+                if isinstance(entry, dict):
+                    rules.append(
+                        {
+                            "category": entry.get("category", "unknown"),
+                            "title": entry.get("title", entry.get("category", "")),
+                            "content": entry.get("content", ""),
+                            "source": source,
+                        }
+                    )
+            candidates = ()
+        else:
+            candidates = data.items()
+
+        for key, value in candidates:
+            if key == "rules":
+                continue
+
+            description_parts: List[str] = []
+            if isinstance(value, dict):
+                if "description" in value:
+                    description_parts.append(str(value["description"]))
+
+                extra = {k: v for k, v in value.items() if k not in {"description", "title"}}
+                if extra:
+                    description_parts.append(json.dumps(extra, ensure_ascii=False, indent=2))
+
+                title = value.get("title", key)
+            else:
+                title = key
+                description_parts.append(str(value))
+
+            rules.append(
+                {
+                    "category": str(key),
+                    "title": str(title),
+                    "content": "\n".join(part for part in description_parts if part).strip(),
+                    "source": source,
+                }
+            )
+
+    elif isinstance(data, list):
+        for entry in data:
+            rules.append(
+                {
+                    "category": "list_item",
+                    "title": str(entry),
+                    "content": str(entry),
+                    "source": source,
+                }
+            )
+
+    return {"rules": rules}
+
+
+def parse_documents(directory: Union[str, Path], save_path: Union[str, Path] = "parsed_all.json") -> Dict[str, Dict[str, List[Dict[str, str]]]]:
+    """`directory` 아래의 문서를 순회하면서 규칙 데이터를 생성합니다."""
+
+    docs_dir = Path(directory)
+    parsed_output: Dict[str, Dict[str, List[Dict[str, str]]]] = {}
+
+    if not docs_dir.exists():
+        return parsed_output
+
+    for file_path in sorted(docs_dir.iterdir()):
+        if not file_path.is_file():
+            continue
+
+        suffix = file_path.suffix.lower()
+        if suffix in TEXT_EXTENSIONS:
+            content = file_path.read_text(encoding="utf-8", errors="ignore")
+            parsed = parse_content(content)
+            for rule in parsed.get("rules", []):
+                rule.setdefault("source", file_path.name)
+            parsed_output[file_path.name] = parsed
+        elif suffix == ".json":
+            try:
+                data = json.loads(file_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                data = {"rules": []}
+            parsed_output[file_path.name] = _normalize_json_rules(data, file_path.name)
+
+    save_path = Path(save_path)
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    to_dump = parsed_output if parsed_output else {}
+    save_path.write_text(
+        json.dumps(to_dump, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    return parsed_output
+
+
+def save_parsed(data, filename: Union[str, Path] = "parsed_all.json") -> None:
+    """Streamlit UI에서 직접 저장할 때 사용."""
+
+    path = Path(filename)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/project_st_v6/runner.py
+++ b/project_st_v6/runner.py
@@ -1,15 +1,23 @@
-from saju_system import SajuAnalyzer
+from pathlib import Path
+
 from parser import parse_documents
+from system import SajuAnalyzer
 
 if __name__ == "__main__":
-    print("📂 문서 파싱...")
-    parsed = parse_documents("docs")
+    base_dir = Path(__file__).resolve().parent
+    docs_dir = base_dir / "docs"
+    parsed_output = base_dir / "parsed_all.json"
+    report_path = base_dir / "reports" / "analysis.md"
 
-    analyzer = SajuAnalyzer(parsed_data_path="parsed/parsed_keywords.json")
+    print("📂 문서 파싱...")
+    parsed = parse_documents(docs_dir, save_path=parsed_output)
+    print(f"  └ 처리된 문서 수: {len(parsed)}")
+
+    analyzer = SajuAnalyzer(parsed_data_path=str(parsed_output))
     report = analyzer.build_report()
 
     print(report)
 
-    with open("reports/analysis.md", "w", encoding="utf-8") as f:
-        f.write(report)
-    print("📑 저장 완료: reports/analysis.md")
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(report, encoding="utf-8")
+    print(f"📑 저장 완료: {report_path.relative_to(base_dir)}")


### PR DESCRIPTION
## Summary
- repair the CLI runner to load the correct analyzer module and manage output paths safely
- extend the parser utilities to normalize JSON knowledge bases and batch-parse documents into a shared dataset
- ignore generated artifacts from the CLI workflow to keep the repository clean

## Testing
- python project_st_v6/runner.py

------
https://chatgpt.com/codex/tasks/task_e_68d8e7d3f718833086423cf1db175457